### PR TITLE
[BUG-#20] Include header files in CMake configuration

### DIFF
--- a/traceur-core/CMakeLists.txt
+++ b/traceur-core/CMakeLists.txt
@@ -28,8 +28,29 @@ else()
 endif()
 
 add_library(traceur-core STATIC
+	include/traceur/core/kernel/kernel.hpp
+	include/traceur/core/kernel/pixel.hpp
+	include/traceur/core/kernel/film.hpp
+	include/traceur/core/kernel/hit.hpp
+	include/traceur/core/kernel/ray.hpp
+	include/traceur/core/kernel/basic.hpp
 	src/traceur/core/kernel/basic.cpp
+
+	include/traceur/core/lightning/light.hpp
+	include/traceur/core/material/material.hpp
+	include/traceur/core/scene/scene.hpp
+	include/traceur/core/scene/camera.hpp
+	include/traceur/core/scene/graph/graph.hpp
+	include/traceur/core/scene/graph/builder.hpp
+	include/traceur/core/scene/graph/factory.hpp
+	include/traceur/core/scene/graph/visitor.hpp
+	include/traceur/core/scene/primitive/primitive.hpp
+	include/traceur/core/scene/primitive/box.hpp
+	include/traceur/core/scene/primitive/triangle.hpp
 	src/traceur/core/scene/graph/vector.cpp
+
+	include/traceur/exporter/exporter.hpp
+	include/traceur/loader/loader.hpp
 )
 target_include_directories(traceur-core PUBLIC include/)
 target_link_libraries(traceur-core GLM::GLM)

--- a/traceur-frontend-glut/CMakeLists.txt
+++ b/traceur-frontend-glut/CMakeLists.txt
@@ -29,7 +29,13 @@ else()
 	add_library(GLUT::GLUT ALIAS freeglut_static)
 endif()
 
-add_executable(traceur-frontend-glut 
+add_executable(traceur-frontend-glut
+	include/traceur/frontend/glut/visitor.hpp
+	include/imageWriter.h
+	include/matrix.h
+	include/raytracing.h
+	include/traqueboule.h
+
 	src/main.cpp
 	src/raytracing.cpp
 	src/frontend/glut/visitor.cpp

--- a/traceur-loader-obj/CMakeLists.txt
+++ b/traceur-loader-obj/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 set(CMAKE_CXX_STANDARD 14)
 
 add_library(traceur-loader-obj STATIC
+	include/traceur/loader/obj.hpp
 	src/traceur/loader/obj.cpp
 )
 target_include_directories(traceur-loader-obj PUBLIC include/)


### PR DESCRIPTION
This change includes the header files of the project in the CMake
configuration, so that IDEs know the location of the header files and
can list them.

Fixes #20