### PR TITLE
[BUG-#26] Fix reference to commit in submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/g-truc/glm.git
 [submodule "traceur-frontend-glut/deps/freeglut"]
 	path = traceur-frontend-glut/deps/freeglut
-	url = https://github.com/dcnieho/FreeGLUT.git
+	url = https://github.com/fabianishere/FreeGLUT.git


### PR DESCRIPTION
This change fixes the reference to a commit in the FreeGLUT submodule,
which made the fetching of the submodules fail.