### PR TITLE
[FEATURE-#73] Add progress counter to GLUT frontend

### DIFF
--- a/traceur-core/include/traceur/core/kernel/film.hpp
+++ b/traceur-core/include/traceur/core/kernel/film.hpp
@@ -143,6 +143,26 @@ namespace traceur {
 		{
 			return buffer[pos.y * width + pos.x];
 		}
+
+		/**
+		 * Return the frame buffer of this film.
+		 *
+		 * @return the frame buffer of this film.
+		 */
+		traceur::Pixel * data()
+		{
+			return buffer.data();
+		}
+
+		/**
+		 * Return the frame buffer of this film.
+		 *
+		 * @return the frame buffer of this film.
+		 */
+		const traceur::Pixel * data() const
+		{
+			return buffer.data();
+		}
 	};
 
 	/**

--- a/traceur-core/include/traceur/core/kernel/observer.hpp
+++ b/traceur-core/include/traceur/core/kernel/observer.hpp
@@ -34,8 +34,11 @@ namespace traceur {
 	class Film;
 
 	/**
-	 * An observer that observes render jobs running on a kernel. An observer is
-	 * not thread-safe.
+	 * A {@link KernelObserver} observes a {@link Kernel} instance and is
+	 * notified of events happening in the kernel.
+	 *
+	 * A kernel does not provide any synchronisation guarantees for an observer
+	 * and therefore this class is not thread-safe.
 	 */
 	class KernelObserver {
 	public:
@@ -62,10 +65,12 @@ namespace traceur {
 		 * the kernel.
 		 *
 		 * @param[in] kernel The kernel that is rendering the scene.
+		 * @param[in] id The identifier of the partition.
 		 * @param[in] film The {@link Film} the kernel renders the scene on.
 		 * @param[in] offset The offset within the film.
 		 */
 		virtual void partitionStarted(const traceur::Kernel &,
+									  int,
 									  const traceur::Film &,
 									  const glm::ivec2 &) {}
 
@@ -74,10 +79,13 @@ namespace traceur {
 		 * on the kernel.
 		 *
 		 * @param[in] kernel The kernel that is rendering the scene.
+		 * @param[in] id The identifier of the partition.
 		 * @param[in] film The {@link Film} the kernel has rendered the scene on.
 		 * @param[in] offset The offset within the film.
+		 * @param[in] partition The identifier of the partition
 		 */
 		virtual void partitionFinished(const traceur::Kernel &,
+									   int,
 									   const traceur::Film &,
 									   const glm::ivec2 &) {}
 

--- a/traceur-core/src/traceur/core/kernel/basic.cpp
+++ b/traceur-core/src/traceur/core/kernel/basic.cpp
@@ -265,7 +265,7 @@ void traceur::BasicKernel::render(const traceur::Scene &scene,
 	/* Notify observers about render */
 	for (auto &observer : observers) {
 		observer->renderStarted(*this, scene, camera, 1);
-		observer->partitionStarted(*this, film, offset);
+		observer->partitionStarted(*this, 0, film, offset);
 	}
 
 	traceur::Ray ray;
@@ -291,7 +291,7 @@ void traceur::BasicKernel::render(const traceur::Scene &scene,
 
 	/* Notify observers about finish */
 	for (auto &observer : observers) {
-		observer->partitionFinished(*this, film, offset);
+		observer->partitionFinished(*this, 0, film, offset);
 		observer->renderFinished(*this, film);
 	}
 }

--- a/traceur-core/src/traceur/core/kernel/multithreaded.cpp
+++ b/traceur-core/src/traceur/core/kernel/multithreaded.cpp
@@ -61,14 +61,14 @@ std::unique_ptr<traceur::Film> traceur::MultithreadedKernel::render(
 
 			/* Notify observers about start */
 			for (auto &observer : observers) {
-				observer->partitionStarted(*this, partition, offset);
+				observer->partitionStarted(*this, i, partition, offset);
 			}
 			/* Render the partition */
 			kernel->render(scene, camera, partition, offset);
 
 			/* Notify observers about finish */
 			for (auto &observer : observers) {
-				observer->partitionFinished(*this, partition, offset);
+				observer->partitionFinished(*this, i, partition, offset);
 			}
 		}));
 	}

--- a/traceur-frontend-glut/include/traceur/frontend/glut/observer.hpp
+++ b/traceur-frontend-glut/include/traceur/frontend/glut/observer.hpp
@@ -52,10 +52,12 @@ namespace traceur {
 		 * the kernel.
 		 *
 		 * @param[in] kernel The kernel that is rendering the scene.
+		 * @param[in] id The identifier of the partition.
 		 * @param[in] film The {@link Film} the kernel renders the scene on.
 		 * @param[in] offset The offset within the film.
 		 */
 		virtual void partitionStarted(const traceur::Kernel &,
+									  int,
 									  const traceur::Film &,
 									  const glm::ivec2 &) final;
 
@@ -64,10 +66,13 @@ namespace traceur {
 		 * on the kernel.
 		 *
 		 * @param[in] kernel The kernel that is rendering the scene.
+		 * @param[in] id The identifier of the partition.
 		 * @param[in] film The {@link Film} the kernel has rendered the scene on.
 		 * @param[in] offset The offset within the film.
+		 * @param[in] partition The identifier of the partition
 		 */
 		virtual void partitionFinished(const traceur::Kernel &,
+									   int,
 									   const traceur::Film &,
 									   const glm::ivec2 &) final;
 

--- a/traceur-frontend-glut/src/frontend/glut/observer.cpp
+++ b/traceur-frontend-glut/src/frontend/glut/observer.cpp
@@ -22,16 +22,23 @@
  * THE SOFTWARE.
  */
 
+#include <map>
 #include <stdio.h>
 
 #include <traceur/core/kernel/kernel.hpp>
 #include <traceur/frontend/glut/observer.hpp>
+
+extern std::vector<std::tuple<glm::ivec2, glm::ivec2, bool>> parts;
 
 void traceur::ProgressObserver::renderStarted(const traceur::Kernel &kernel,
 											  const traceur::Scene &,
 											  const traceur::Camera &,
 											  int partitions)
 {
+	parts.clear();
+	parts.resize(static_cast<unsigned long>(partitions));
+
+	/* Start timing and progress */
 	this->partitions = partitions;
 	printf("[%s] Rendering scene\n", kernel.name().c_str());
 
@@ -46,22 +53,31 @@ void traceur::ProgressObserver::renderStarted(const traceur::Kernel &kernel,
 
 
 void traceur::ProgressObserver::partitionStarted(const traceur::Kernel &,
-												 const traceur::Film &,
-												 const glm::ivec2 &) {}
+												 int id,
+												 const traceur::Film &film,
+												 const glm::ivec2 &offset)
+{
+	parts[id] = std::tuple<glm::ivec2, glm::ivec2, bool>(glm::ivec2(film.width, film.height), offset, false);
+}
 
 void traceur::ProgressObserver::partitionFinished(const traceur::Kernel &kernel,
-												  const traceur::Film &,
-												  const glm::ivec2 &)
+												  int id,
+												  const traceur::Film &film,
+												  const glm::ivec2 &offset)
 {
+	/* Increase progress meter */
 	int finished = ++this->finished;
 	float percentage = ((float)finished / partitions) * 100;
 	printf("\r[%s] Progress: %0.f%% (%d/%d)", kernel.name().c_str(), percentage, finished, partitions);
 	fflush(stdout);
+
+	parts[id] = std::tuple<glm::ivec2, glm::ivec2, bool>(glm::ivec2(film.width, film.height), offset, true);
 }
 
 void traceur::ProgressObserver::renderFinished(const traceur::Kernel &kernel,
 											   const traceur::Film &)
 {
+	/* Finish progress meter */
 	printf("\n");
 	// Calculate the elapsed time
 	auto wallB = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This change adds a progress counter which shows the partitions that have
been rendered and those which are currently being rendered. Enable this
feature by pressing 'p'.