### PR TITLE
Fix build on Windows

### DIFF
--- a/traceur-frontend-glut/src/frontend/glut/observer.cpp
+++ b/traceur-frontend-glut/src/frontend/glut/observer.cpp
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  */
 
+#include <ctime>
+#include <chrono>
 #include <map>
 #include <stdio.h>
 


### PR DESCRIPTION
This change fixes the build on Windows, which was failing due to an import missing.