### PR TITLE
[BUG-#80] Fix split on incorrect axis

### DIFF
--- a/traceur-core/include/traceur/core/scene/primitive/box.hpp
+++ b/traceur-core/include/traceur/core/scene/primitive/box.hpp
@@ -37,7 +37,7 @@ namespace traceur {
 		 * An axis of the box.
 		 */
 		enum class Axis: int {
-			X = 0, Y = 1, Z = 1
+			X = 0, Y = 1, Z = 2
 		};
 
 		/**


### PR DESCRIPTION
This change fixes a bug where the KD tree build process splits on the
y-axis, while the z-axis is the largest due to a typo.

Closes #80