### PR TITLE
chore(#88): Remove support for old mingw32 targets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/g-truc/glm.git
 [submodule "traceur-frontend-glut/deps/freeglut"]
 	path = traceur-frontend-glut/deps/freeglut
-	url = https://github.com/fabianishere/FreeGLUT.git
+	url = https://github.com/dcnieho/FreeGLUT.git
 [submodule "traceur-loader-wavefront/deps/filesystem"]
 	path = traceur-loader-wavefront/deps/filesystem
 	url = https://github.com/wjakob/filesystem


### PR DESCRIPTION
This change removes the support for older mingw32 targets by not
providing a patched FreeGLUT dependency to the user. This dependency
will be deprecated in the future, so this should hopefully not affect
many users.

Closes #88